### PR TITLE
changes to work with catsup csv input

### DIFF
--- a/modules/analysis.nf
+++ b/modules/analysis.nf
@@ -113,6 +113,7 @@ process FN4_upload {
 
     oci os object put \
 	-bn FN4-queue \
+	--force \
         --auth instance_principal \
 	--file ${sampleName}.fasta \
 	--metadata "{\\"sampleID\\":\\"$sampleName\\"}"

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -185,7 +185,7 @@ process getObjFilesONT {
     tag { prefix }
 
     input:
-        tuple bucket, prefix
+        tuple bucket, filePrefix, prefix
 
     output:
         tuple prefix, path("${prefix}.fastq.gz")
@@ -198,18 +198,18 @@ process getObjFilesONT {
 		--download-dir ./ \
 		--overwrite \
 		--auth instance_principal \
-		--prefix $prefix
+		--prefix $filePrefix
 
 	kraken2 -db ${db} \
 		--memory-mapping \
 		--report ${prefix}_summary.txt \
 		--output ${prefix}_read_classification \
-        	*.fastq.gz 
+        	${filePrefix}**.fastq.gz 
 
         awk '\$3==\"9606\" { print \$2 }' ${prefix}_read_classification >> kraken2_human_read_list
         awk '\$3!=\"9606\" { print \$2 }' ${prefix}_read_classification >> kraken2_nonhuman_read_list
 
-        seqs=*.fastq.gz
+        seqs=${filePrefix}**.fastq.gz
         for seq in \${seqs}
         do
 	    seqtk subseq \${seq} kraken2_nonhuman_read_list | gzip >> "${prefix}.fastq.gz"

--- a/modules/illumina.nf
+++ b/modules/illumina.nf
@@ -193,7 +193,7 @@ process getObjFiles {
     tag { prefix }
 
     input:
-        tuple bucket, prefix
+        tuple bucket, filePrefix, prefix
 
     output:
         tuple prefix, path("${prefix}_C1.fastq.gz"), path("${prefix}_C2.fastq.gz")
@@ -206,19 +206,19 @@ process getObjFiles {
 		--download-dir ./ \
 		--overwrite \
 		--auth instance_principal \
-		--prefix $prefix
+		--prefix $filePrefix
 
 	kraken2 --paired -db ${db} \
 		--memory-mapping \
 		--report ${prefix}_summary.txt \
 		--output ${prefix}_read_classification \
-        	${prefix}_1.fastq.gz ${prefix}_2.fastq.gz
+        	${filePrefix}*1.fastq.gz ${filePrefix}*2.fastq.gz
 
         awk '\$3==\"9606\" { print \$2 }' ${prefix}_read_classification >> kraken2_human_read_list
         awk '\$3!=\"9606\" { print \$2 }' ${prefix}_read_classification >> kraken2_nonhuman_read_list
 
-	seqtk subseq ${prefix}_1.fastq.gz kraken2_nonhuman_read_list | gzip > "${prefix}_C1.fastq.gz"
-	seqtk subseq ${prefix}_2.fastq.gz kraken2_nonhuman_read_list | gzip > "${prefix}_C2.fastq.gz"
+	seqtk subseq ${filePrefix}*1.fastq.gz kraken2_nonhuman_read_list | gzip > "${prefix}_C1.fastq.gz"
+	seqtk subseq ${filePrefix}*2.fastq.gz kraken2_nonhuman_read_list | gzip > "${prefix}_C2.fastq.gz"
 	"""
 }
 


### PR DESCRIPTION
a few changes to the nextflow to work with mounted S3 buckets.

Needs bucket to be mounted on head node like such:

```bash
mkdir -p /data/inputs/s3/oracle-test
s3fs catsup-test /data/inputs/s3/oracle-test -o passwd_file=/home/ubuntu/.passwd-s3fs-oracle-test -o url=https://lrbvkel2wjot.compat.objectstorage.uk-london-1.oraclecloud.com -o use_path_request_style -o uid=1001,gid=1001
```

Will need to decide on bucket policies and adding this to terraforming scripts.