### PR TITLE
Using ci containers

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -113,27 +113,27 @@ sp3 {
       process {
           withName:articDownloadScheme {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-nanopore.sif"
+              container = "/data/images/artic-ncov2019-nanopore_VERSION.sif"
       }
           withName:articGuppyPlex {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-nanopore.sif"
+              container = "/data/images/artic-ncov2019-nanopore_VERSION.sif"
       }
           withName:articMinIONMedaka {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-nanopore.sif"
+              container = "/data/images/artic-ncov2019-nanopore_VERSION.sif"
       }
           withName:articRemoveUnmappedReads {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-nanopore.sif"
+              container = "/data/images/artic-ncov2019-nanopore_VERSION.sif"
       }
           withName:makeQCCSV {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-nanopore.sif"
+              container = "/data/images/artic-ncov2019-nanopore_VERSION.sif"
       }
           withName:writeQCSummaryCSV {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-nanopore.sif"
+              container = "/data/images/artic-ncov2019-nanopore_VERSION.sif"
       }
           withName:getObjFilesONT {
               singularity.enabled = true
@@ -165,50 +165,50 @@ sp3 {
       }
           withName:makeReport {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
     }
     }
     } else if (params.illumina) {
       process {
           withName:articDownloadScheme {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
       }
           withName:indexReference {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
       }
           withName:readTrimming {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
       }
           withName:readMapping {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
       }
           withName:trimPrimerSequences {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
       }
           withName:callVariants {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
       }
           withName:makeConsensus {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
       }
           withName:makeQCCSV {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
       }
           withName:writeQCSummaryCSV {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
       }
           withName:collateSamples {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
       }
           withName:getObjFiles {
               singularity.enabled = true
@@ -240,7 +240,7 @@ sp3 {
       }
           withName:makeReport {
               singularity.enabled = true
-              container = "/data/images/artic-ncov2019-illumina.sif"
+              container = "/data/images/artic-ncov2019-illumina_VERSION.sif"
     }
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -137,31 +137,31 @@ sp3 {
       }
           withName:getObjFilesONT {
               singularity.enabled = true
-              container = '/data/images/oci_download-2021-06-03-a71ecf9e3172.simg'
+              container = '/data/images/oci_pipeline_VERSION.sif'
       }
           withName:pango {
               singularity.enabled = true
-              container = '/data/images/pangolinimg-2021-06-15-1ce80b30e1ef.simg'
+              container = '/data/images/pango_VERSION.sif'
       }
           withName:nextclade {
               singularity.enabled = true
-              container = '/data/images/neherlab_nextclade-2021-03-30-f27396d6572d.simg'
+              container = '/data/images/nextclade_VERSION.sif'
       }
           withName:getVariantDefinitions {
               singularity.enabled = true
-              container = '/data/images/aln2type-2021-05-21-5fdc634aba8c.simg'
+              container = '/data/images/aln2type_VERSION.sif'
       }
           withName:aln2type {
               singularity.enabled = true
-              container = '/data/images/aln2type-2021-05-21-5fdc634aba8c.simg'
+              container = '/data/images/aln2type_VERSION.sif'
       }
           withName:articMinIONViridian {
               singularity.enabled = true
-              container = '/data/images/viridian_workflow.img'
+              container = '/data/images/viridian_workflow_VERID_VER.img'
       }
           withName:FN4_upload {
               singularity.enabled = true
-              container = '/data/images/fn4upload-2021-06-22-46e23f35c1d4.simg'
+              container = '/data/images/fn4upload_VERSION.sif'
       }
           withName:makeReport {
               singularity.enabled = true
@@ -212,31 +212,31 @@ sp3 {
       }
           withName:getObjFiles {
               singularity.enabled = true
-              container = '/data/images/oci_download-2021-06-03-a71ecf9e3172.simg'
+              container = '/data/images/oci_pipeline_VERSION.sif'
       }
           withName:pango {
               singularity.enabled = true
-              container = '/data/images/pangolinimg-2021-06-15-1ce80b30e1ef.simg'
+              container = '/data/images/pango_VERSION.sif'
       }
           withName:nextclade {
               singularity.enabled = true
-              container = '/data/images/neherlab_nextclade-2021-03-30-f27396d6572d.simg'
+              container = '/data/images/nextclade_VERSION.sif'
       }
           withName:getVariantDefinitions {
               singularity.enabled = true
-              container = '/data/images/aln2type-2021-05-21-5fdc634aba8c.simg'
+              container = '/data/images/aln2type_VERSION.sif'
       }
           withName:aln2type {
               singularity.enabled = true
-              container = '/data/images/aln2type-2021-05-21-5fdc634aba8c.simg'
+              container = '/data/images/aln2type_VERSION.sif'
       }
           withName:viridian {
               singularity.enabled = true
-              container = '/data/images/viridian_workflow.img'
+              container = '/data/images/viridian_workflow_VERID_VER.img'
       }
           withName:FN4_upload {
               singularity.enabled = true
-              container = '/data/images/fn4upload-2021-06-22-46e23f35c1d4.simg'
+              container = '/data/images/fn4upload_VERSION.sif'
       }
           withName:makeReport {
               singularity.enabled = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -161,7 +161,7 @@ sp3 {
       }
           withName:FN4_upload {
               singularity.enabled = true
-              container = '/data/images/fn4upload_VERSION.sif'
+              container = '/data/images/fn4_upload_VERSION.sif'
       }
           withName:makeReport {
               singularity.enabled = true
@@ -236,7 +236,7 @@ sp3 {
       }
           withName:FN4_upload {
               singularity.enabled = true
-              container = '/data/images/fn4upload_VERSION.sif'
+              container = '/data/images/fn4_upload_VERSION.sif'
       }
           withName:makeReport {
               singularity.enabled = true


### PR DESCRIPTION
Changed nextflow.config to have generic identifiers for container names that can be automatically changed in the sp3 install scripts to use the latest versions.