### PR TITLE
Fn4 bucket name

### DIFF
--- a/modules/analysis.nf
+++ b/modules/analysis.nf
@@ -167,7 +167,7 @@ process FN4_upload {
     FN4ormater.py -i ${sampleName}_wuhan.fa -r MN908947.3 -s ${sampleName} -o ${sampleName}.fasta
 
     oci os object put \
-	   -bn $bucketName \
+	   -bn ${params.bucketNameFN4} \
 	   --force \
        --auth instance_principal \
 	   --file ${sampleName}.fasta \

--- a/modules/analysis.nf
+++ b/modules/analysis.nf
@@ -167,11 +167,11 @@ process FN4_upload {
     FN4ormater.py -i ${sampleName}_wuhan.fa -r MN908947.3 -s ${sampleName} -o ${sampleName}.fasta
 
     oci os object put \
-	-bn FN4-queue \
-	--force \
-        --auth instance_principal \
-	--file ${sampleName}.fasta \
-	--metadata "{\\"sampleID\\":\\"$sampleName\\"}"
+	   -bn $bucketName \
+	   --force \
+       --auth instance_principal \
+	   --file ${sampleName}.fasta \
+	   --metadata "{\\"sampleID\\":\\"$sampleName\\"}"
 
     """
 }

--- a/modules/analysis.nf
+++ b/modules/analysis.nf
@@ -167,11 +167,11 @@ process FN4_upload {
     FN4ormater.py -i ${sampleName}_wuhan.fa -r MN908947.3 -s ${sampleName} -o ${sampleName}.fasta
 
     oci os object put \
-	   -bn ${params.bucketNameFN4} \
-	   --force \
-       --auth instance_principal \
-	   --file ${sampleName}.fasta \
-	   --metadata "{\\"sampleID\\":\\"$sampleName\\"}"
+	-bn ${params.bucketNameFN4} \
+	--force \
+        --auth instance_principal \
+	--file ${sampleName}.fasta \
+	--metadata "{\\"sampleID\\":\\"$sampleName\\"}"
 
     """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,7 @@ params {
 
   // upload bucket
   uploadBucket=false
+  bucketName = 'FN4-queue'
  
   // primers
   primers='auto'

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,7 +24,7 @@ params {
 
   // upload bucket
   uploadBucket=false
-  bucketName = 'FN4-queue'
+  bucketNameFN4 = 'FN4-queue'
  
   // primers
   primers='auto'


### PR DESCRIPTION
`bucketNameFN4` is now accepted as a parameter. Required because PROD and DEV now have different buckets