### PR TITLE
Use existing param 'run_uuid' to generate a unique launch dir

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -36,6 +36,9 @@ params {
 
   // process fork limit
   myMaxForks = false
+
+  // execution UUID
+  run_uuid = 'no_uuid'
 }
 
 // Load base.config by default for all pipelines
@@ -384,6 +387,7 @@ profiles {
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
             storageMountPath = '/work'
+            launchDir = "/work/ubuntu/${params.run_uuid}"
 
             serviceAccount = 'default'
             projectDir = '/work/project'

--- a/nextflow.config
+++ b/nextflow.config
@@ -387,7 +387,7 @@ profiles {
             namespace = 'default'
             storageClaimName = 'default-nextflow-fss-storage-work-pvc'
             storageMountPath = '/work'
-            launchDir = "/work/ubuntu/${params.run_uuid}"
+            launchDir = "/work/runs/${params.run_uuid}"
 
             serviceAccount = 'default'
             projectDir = '/work/project'


### PR DESCRIPTION
To handle the logs and trace files from multiple Nextflow runs, and to avoid collisions of work folders from multiple Nextflow runs, we need to set a unique folder path for each run. This change is to make use of 'launchDir' config settings available in the Nextflow config to achieve this goal. 